### PR TITLE
feat(jar_balance) add copy address button

### DIFF
--- a/components/cookie-jar-balance.tsx
+++ b/components/cookie-jar-balance.tsx
@@ -51,28 +51,25 @@ const CookieJarBalance = ({
       <p>Claim period: {periodLength}</p>
       <p>Owned by: {truncateEthereumAddress(owner)}</p>
       <div className="flex flex-row items-center gap-x-2">
-        <div className="flex flex-row items-center gap-x-1">
-          <span>Jar address</span>
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info
-                  size={16}
-                  strokeWidth={2}
-                  aria-label="Information about jar address"
-                  className="rounded-md text-gray-400 hover:bg-accent hover:text-white"
-                />
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>
-                  This is the address of the safe that holds CookieJar funds.
-                  Use this if you want to fund the jar from a DAO or Multisig
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <span>: {truncateEthereumAddress(owner)}</span>
-        </div>
+        <span>Jar address: {truncateEthereumAddress(owner)}</span>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info
+                size={16}
+                strokeWidth={2}
+                aria-label="Information about jar address"
+                className="rounded-md text-gray-400 hover:bg-accent hover:text-white"
+              />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                This is the address of the safe that holds CookieJar funds. Use
+                this if you want to fund the jar from a DAO or Multisig
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <Button
           variant="ghost"
           size="icon"

--- a/components/cookie-jar-balance.tsx
+++ b/components/cookie-jar-balance.tsx
@@ -6,6 +6,9 @@ import { useBalance, useReadContract } from "wagmi";
 
 import { formatEther } from "viem";
 import { truncateEthereumAddress } from "@/lib/utils";
+import { Button } from "./ui/button";
+import { Copy } from "lucide-react";
+import { useToast } from "./ui/use-toast";
 
 const CookieJarBalance = ({
   cookieToken,
@@ -28,6 +31,8 @@ const CookieJarBalance = ({
     token: cookieToken,
   });
 
+  const { toast } = useToast();
+
   return (
     <div className="flex flex-col">
       {isLoading && <div>Loading...</div>}
@@ -39,7 +44,24 @@ const CookieJarBalance = ({
         </p>
       )}
       <p>Claim period: {periodLength}</p>
-      <p>Owned by: {truncateEthereumAddress(owner)}</p>
+      <div className="flex flex-row gap-x-2">
+        <span>Owned by: {truncateEthereumAddress(owner)} </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-gray-400 hover:text-white"
+          aria-label="Copy address"
+          onClick={() => {
+            navigator.clipboard.writeText(owner);
+            toast({
+              variant: "default",
+              description: `Address copied!`,
+            });
+          }}
+        >
+          <Copy className="h-4 w-4" />
+        </Button>
+      </div>
     </div>
   );
 };

--- a/components/cookie-jar-balance.tsx
+++ b/components/cookie-jar-balance.tsx
@@ -2,13 +2,18 @@
 import React from "react";
 import type { Address } from "viem";
 
-import { useBalance, useReadContract } from "wagmi";
+import { useBalance } from "wagmi";
 
-import { formatEther } from "viem";
 import { truncateEthereumAddress } from "@/lib/utils";
 import { Button } from "./ui/button";
-import { Copy } from "lucide-react";
+import { Copy, Info } from "lucide-react";
 import { useToast } from "./ui/use-toast";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 const CookieJarBalance = ({
   cookieToken,
@@ -44,15 +49,37 @@ const CookieJarBalance = ({
         </p>
       )}
       <p>Claim period: {periodLength}</p>
-      <div className="flex flex-row gap-x-2">
-        <span>Owned by: {truncateEthereumAddress(owner)} </span>
+      <p>Owned by: {truncateEthereumAddress(owner)}</p>
+      <div className="flex flex-row items-center gap-x-2">
+        <div className="flex flex-row items-center gap-x-1">
+          <span>Jar address</span>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info
+                  size={16}
+                  strokeWidth={2}
+                  aria-label="Information about jar address"
+                  className="rounded-md text-gray-400 hover:bg-accent hover:text-white"
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>
+                  This is the address of the safe that holds CookieJar funds.
+                  Use this if you want to fund the jar from a DAO or Multisig
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <span>: {truncateEthereumAddress(owner)}</span>
+        </div>
         <Button
           variant="ghost"
           size="icon"
           className="h-6 w-6 text-gray-400 hover:text-white"
           aria-label="Copy address"
           onClick={() => {
-            navigator.clipboard.writeText(owner);
+            navigator.clipboard.writeText(jarTargetAddress);
             toast({
               variant: "default",
               description: `Address copied!`,


### PR DESCRIPTION
## Summary
fixes #27

## Description
1- added a button icon that will copy the owner address which is the same as target address.
2- A toast to display that the address is copied

## ScreenShot
![image](https://github.com/user-attachments/assets/b839e09e-9027-4a04-aaf7-8136210097f8)
