### PR TITLE
add copy address button

### DIFF
--- a/components/cookie-jar-balance.tsx
+++ b/components/cookie-jar-balance.tsx
@@ -6,6 +6,9 @@ import { useBalance, useReadContract } from "wagmi";
 
 import { formatEther } from "viem";
 import { truncateEthereumAddress } from "@/lib/utils";
+import { Button } from "./ui/button";
+import { Copy } from "lucide-react";
+import { useToast } from "./ui/use-toast";
 
 const CookieJarBalance = ({
   cookieToken,
@@ -28,6 +31,8 @@ const CookieJarBalance = ({
     token: cookieToken,
   });
 
+  const { toast } = useToast();
+
   return (
     <div className="flex flex-col">
       {isLoading && <div>Loading...</div>}
@@ -39,7 +44,24 @@ const CookieJarBalance = ({
         </p>
       )}
       <p>Claim period: {periodLength}</p>
-      <p>Owned by: {truncateEthereumAddress(owner)}</p>
+      <div className="flex flex-row gap-x-2">
+        <span>Owned by: {truncateEthereumAddress(owner)} </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-gray-400 hover:text-white"
+          aria-label="Copy address"
+          onClick={() => {
+            navigator.clipboard.writeText(owner);
+            toast({
+              variant: "default",
+              description: `Address copied!`,
+            });
+          }}
+        >
+          <Copy className="h-4 w-4" />
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
fixes #27

## Description
1- added a button icon that will copy the Jar target address. @0xRowdy 
2- A toast to display that the address is copied.
2- A tooltip to explain Jar target address purpose.

## ScreenShot
![image](https://github.com/user-attachments/assets/8effaf9c-edd4-4e6e-8422-7c9983deded9)

